### PR TITLE
Refactor child process handling

### DIFF
--- a/bin/galen
+++ b/bin/galen
@@ -2,8 +2,9 @@
 
 var sys = require('sys');
 var exec = require('child_process').exec;
-var curDir = require("path").resolve('.');
-var baseDir = require('path').dirname(require.main.filename);
+var path = require('path');
+var curDir = path.resolve('.');
+var baseDir = path.dirname(require.main.filename);
 
 function puts(error, stdout, stderr) {
 	console.log(stdout);

--- a/bin/galen
+++ b/bin/galen
@@ -1,26 +1,26 @@
 #!/usr/bin/env node
 
 var sys = require('sys');
-var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
 var path = require('path');
 var curDir = path.resolve('.');
 var baseDir = path.dirname(require.main.filename);
-
-function puts(error, stdout, stderr) {
-    console.log(stdout);
-    console.error(stderr);
-    if (error !== null) {
-        console.error(error);
-    }
-}
+var childProcessOptions = {
+    stdio: 'inherit'
+};
 
 // remove node args
 var args = process.argv.slice(2);
-// create arguments string
-args = args.join(' ');
 
+var programPath;
 if (process.platform === 'win32') {
-        exec(baseDir + '/../lib/galen/galen.bat ' + args, puts);
+    programPath = path.resolve(baseDir, '../lib/galen/galen.bat');
 } else  {
-        exec(baseDir.replace(/\s/g, '\\ ') + '/../lib/galen/galen ' + args, puts);
+    programPath = path.resolve(baseDir, '../lib/galen/galen');
 }
+
+var galenProcess = spawn(programPath, args, childProcessOptions);
+
+galenProcess.on('error', function (error) {
+    console.error(error);
+});

--- a/bin/galen
+++ b/bin/galen
@@ -23,4 +23,5 @@ var galenProcess = spawn(programPath, args, childProcessOptions);
 
 galenProcess.on('error', function (error) {
     console.error(error);
+    process.exit(1);
 });

--- a/bin/galen
+++ b/bin/galen
@@ -25,3 +25,7 @@ galenProcess.on('error', function (error) {
     console.error(error);
     process.exit(1);
 });
+
+galenProcess.on('exit', function (exitCode) {
+    process.exit(exitCode);
+});

--- a/bin/galen
+++ b/bin/galen
@@ -13,10 +13,11 @@ function puts(error, stdout, stderr) {
         console.error(error);
     }
 }
+
 // remove node args
-process.argv.splice(0, 2);
-// create arguments
-var args = process.argv.join(' ');
+var args = process.argv.slice(2);
+// create arguments string
+args = args.join(' ');
 
 if (process.platform === 'win32') {
         exec(baseDir + '/../lib/galen/galen.bat ' + args, puts);

--- a/bin/galen
+++ b/bin/galen
@@ -3,7 +3,6 @@
 var sys = require('sys');
 var spawn = require('child_process').spawn;
 var path = require('path');
-var curDir = path.resolve('.');
 var baseDir = path.dirname(require.main.filename);
 var childProcessOptions = {
     stdio: 'inherit'

--- a/bin/galen
+++ b/bin/galen
@@ -7,11 +7,11 @@ var curDir = path.resolve('.');
 var baseDir = path.dirname(require.main.filename);
 
 function puts(error, stdout, stderr) {
-	console.log(stdout);
-	console.error(stderr);
-	if (error !== null) {
-		console.error(error);
-	}
+    console.log(stdout);
+    console.error(stderr);
+    if (error !== null) {
+        console.error(error);
+    }
 }
 // remove node args
 process.argv.splice(0, 2);


### PR DESCRIPTION
This PR change the executable to use `spawn` instead of `exec`, which allows you to pipe the stdio of the child process to the parent process, so you will see the galen output immediately.