### PR TITLE
Add missing bin file config for core package

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -24,6 +24,9 @@
     "pretest": "jshint -c ../.jshintrc lib/*.js && jshint -c ../.jshintrc *.js",
     "coverage": "istanbul -- cover nodeunit test/tests.js && istanbul-coveralls --no-rm"
   },
+  "bin": {
+      "galen": "bin/galen"
+  },
   "dependencies": {
     "adm-zip": "^0.4.7",
     "fs-extra": "^0.23.0",


### PR DESCRIPTION
The config for the bin file was missing in the `package.json` and it was not possible to run galen via `./node_modules/.bin/galen`.