### PR TITLE
Fix version lookup

### DIFF
--- a/core/install.js
+++ b/core/install.js
@@ -82,7 +82,9 @@ whichDeferred.promise
     }
   })
   .then(function (stdout) {
-    var version = stdout.trim();
+    var regex = /^Version: ([0-9\.]+)$/
+    var result = stdout.trim().match(regex);
+    var version = result[1];
     if (helper.version == version) {
       writeLocationFile(galenPath);
       log.info('galenframework is already installed at', galenPath + '.');


### PR DESCRIPTION
`galen --version` returns 

```
Galen Framework
Version: 2.2.4
JavaScript executor: Rhino 1.7 release 5 2015 01 29
```

https://github.com/galenframework/galen/blob/master/galen-core/src/main/java/com/galenframework/actions/GalenActionVersion.java

and needs to be matched when looking for version number
