### PR TITLE
Change module path resolution method

### DIFF
--- a/cli/bin/galen
+++ b/cli/bin/galen
@@ -79,28 +79,31 @@ var childProcessOptions = {
 // remove node args
 var args = process.argv.slice(2);
 
-// adding chromedriver
+function resolveModulePath(moduleName) {
+  var pathItems = [].slice.call(arguments, 1);
+  pathItems.unshift(path.dirname(require.resolve(moduleName)));
 
-var chromePath = path.resolve(baseDir, '../node_modules/chromedriver/lib/chromedriver/chromedriver');
+  return path.resolve.apply(null, pathItems);
+}
+
+// adding chromedriver
+var chromePath = resolveModulePath('chromedriver', 'chromedriver/chromedriver');
 if (process.platform === 'win32') {
   chromePath += '.exe';
 }
 args.push('-Dwebdriver.chrome.driver=' + chromePath);
-// adding geckodriver
 
-var geckoPath = path.resolve(baseDir, '../node_modules/geckodriver/geckodriver');
+// adding geckodriver
+var geckoPath = resolveModulePath('geckodriver', '..', 'geckodriver');
 if (process.platform === 'win32') {
   geckoPath += '.exe';
 }
 args.push('-Dwebdriver.gecko.driver=' + geckoPath);
 
-var programPath;
+var programPath = resolveModulePath('galenframework', 'lib/galen/galen');
 if (process.platform === 'win32') {
-  programPath = path.resolve(baseDir, '../node_modules/galenframework/lib/galen/galen.bat');
-} else {
-  programPath = path.resolve(baseDir, '../node_modules/galenframework/lib/galen/galen');
+  programPath += '.bat';
 }
-
 
 debugLog('Using following programPath:', programPath);
 debugLog('     ->                args:', args);


### PR DESCRIPTION
Modern NPM and Yarn versions install sub-dependencies in a root of a project's node_modules directory. Due to that, the current way of resolving paths to chromedriver, geckodriver and galenframework doesn't work. They could be not in subdirectories of the galenframework-cli module.
In this PR I use standard Node.js way of resolving module paths - require.resolve to fix this problem.